### PR TITLE
Fixed Testnet stake addresses

### DIFF
--- a/CardanoBech32/CardanoBech32Wrapper.cs
+++ b/CardanoBech32/CardanoBech32Wrapper.cs
@@ -4,7 +4,6 @@ namespace CardanoBech32
 {
   public class CardanoBech32Wrapper : ICardanoBech32Wrapper
   {
-    
     public string ConvertToHexAddressFromBech32(string inBech32)
     {
       if (inBech32 == null) return null;

--- a/CardanoBech32/CardanoBech32Wrapper.cs
+++ b/CardanoBech32/CardanoBech32Wrapper.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace CardanoBech32
 {
   public class CardanoBech32Wrapper : ICardanoBech32Wrapper
   {
+    
     public string ConvertToHexAddressFromBech32(string inBech32)
     {
       if (inBech32 == null) return null;
@@ -50,11 +49,19 @@ namespace CardanoBech32
       if (addressInHex == null) return null;
 
       int stakeAddressLength = 56;
-      var stakeAddressInHex = "e1"+ addressInHex.Substring(addressInHex.Length - stakeAddressLength, stakeAddressLength);
+      var stakeAddressInHex = addressInHex.Substring(addressInHex.Length - stakeAddressLength, stakeAddressLength);
 
-      if (address.StartsWith(AddressType.addr.ToString())) return ConvertToBech32AddressFromHex(stakeAddressInHex, AddressType.stake);
+      if (address.StartsWith(AddressType.addr_test.ToString()))
+      {
+        stakeAddressInHex = "e0" + stakeAddressInHex;
+        return ConvertToBech32AddressFromHex(stakeAddressInHex, AddressType.stake_test);
+      }
 
-      if (address.StartsWith(AddressType.addr_test.ToString())) return ConvertToBech32AddressFromHex(stakeAddressInHex, AddressType.stake_test);
+      if (address.StartsWith(AddressType.addr.ToString()))
+      {
+        stakeAddressInHex = "e1" + stakeAddressInHex;
+        return ConvertToBech32AddressFromHex(stakeAddressInHex, AddressType.stake);
+      }
 
       return null;
     }

--- a/CardanoBech32Test/CardanoBech32Test.cs
+++ b/CardanoBech32Test/CardanoBech32Test.cs
@@ -1,10 +1,5 @@
 ﻿using CardanoBech32;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CardanoBech32Test
 {
@@ -55,14 +50,12 @@ namespace CardanoBech32Test
     [DataTestMethod]
     [DataRow("addr1qx2ezq7geqclknv0n3nhf09c48acm3lpq93frnxhrt84fvkmtgh4vcg6t6ujpr9yrf3gnndc6uufn7xvu2sjqkwqlgkqzq5xdt", "stake1u8d45t6kvyd9awfq3jjp5c5fekudwwyelrxw9gfqt8q05tq3j8dxa")]
     [DataRow("addr1qxdvcswn0exwc2vjfr6u6f6qndfhmk94xjrt5tztpelyk4yg83zn9d4vrrtzs98lcl5u5q6mv7ngmg829xxvy3g5ydls7c76wu", "stake1uxyrc3fjk6kp343gznlu06w2qddk0f5d5r4znrxzg52zxlclk0hlq")]
+    [DataRow("addr_test1qz70gcrx7hf9v95f6wz6r2396dquznyhufcy4x89jl0fvgajwc89ewdzmexrucgl22xy2yr6ycz0q0q2g7ha3e2lk5rqwmwkzu", "stake_test1uze8vrjuhx3dunp7vy049rz9zpazvp8s8s9y0t7cu40m2psthwg0q")]
+    [DataRow("addr_test1qqhzn7ze7qwm9ush55n3ecgzq2l8uvrh7qanys9rzu5dhv4az0dlw2zsg64qcyd8jha9hqanglmxh53p0favshdyrktq9trmz3", "stake_test1uz738klh9pgyd2svzxnet7jmswe50ant6gsh57kgtkjpm9sdwq8ea")]
     public void GetStakeAddressFromAddress_IsValid_True(string address, string stakeAddressCheck)
     {
-
       var stakeAddress = _cBech32.GetStakeAddressFromAddress(address);
-
       Assert.AreEqual(stakeAddress, stakeAddressCheck);
-
     }
-
   }
 }


### PR DESCRIPTION
- Inverted the order of prefix testing in GetStakeAddressFromAddress. 
Testing for "AddressType.addr" was always true, even for testnet addresses.

- Added the correct stake address hex prefix for testnet : "e0"

- Added testnet stake address tests